### PR TITLE
[Docs] - Adding missing return in configureDI method

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ export default function configureDI() {
         "Storage": object(CookieStorage),         // constructor without arguments       
         "BrowserHistory": factory(configureHistory), // factory (will be called only once)  
     });
+    return container;
 }
     
 function configureHistory(container: IDIContainer): History {


### PR DESCRIPTION
- Adding missing return `configureDI` method in README.md. It must return the container since it is using it.