### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,8 @@ export class UserRegistrator {
   public constructor(public readonly userRepository: UserRepository) {}
 
   public async register(userData: SignupData) {
-    // validate
-    const user = this.userRepository.saveNewUser(userData);
-    // send sign up email
-    return user;
+    // validate and send sign up email
+    return this.userRepository.saveNewUser(userData);
   }
 }
 
@@ -134,7 +132,7 @@ export default function configureDI() {
       MyDbProviderUserRepository,
       use(buildDbConnection)
     ),
-    [UserRegistrator.name]: object(UserRegistrator).contrstruct(
+    [UserRegistrator.name]: object(UserRegistrator).construct(
       use(MyDbProviderUserRepository.name)
     ),
     [UserController.name]: func(


### PR DESCRIPTION
Hi there! I was just reading this README and noticed a typo in the construct method - not a big deal but I know this would bug me if I were writing these docs! Also, I fixed an extra line inside ``UserRegistrator``.

![image](https://user-images.githubusercontent.com/65625400/193480369-54a2bec7-3939-4ca6-81e4-138bc8026847.png)
![image](https://user-images.githubusercontent.com/65625400/193480386-482a0f21-b25a-4adc-868c-2719d6611ff0.png)
